### PR TITLE
Fixing overflowing table

### DIFF
--- a/_site/assets/css/style.css
+++ b/_site/assets/css/style.css
@@ -197,11 +197,13 @@ dl p { padding-left: 20px; font-style: italic; }
 
 hr { height: 1px; margin-bottom: 5px; border: none; background: url("../images/bg_hr.png") repeat-x center; }
 
-table { border: 1px solid #373737; margin-bottom: 20px; text-align: left; width : 95%  }
+table { border: 1px solid #373737; margin-bottom: 20px; text-align: left; width : 95%; table-layout:fixed; }
 
 th { font-family: 'Lucida Grande', 'Helvetica Neue', Helvetica, Arial, sans-serif; padding: 10px; background: #373737; color: #fff; }
 
-td { padding: 10px;  }
+td { padding: 10px;  word-wrap: break-word;}
+
+thead { word-wrap: break-word;}
 
 tr { border: 1px solid #373737; }
 


### PR DESCRIPTION
Fixing style bug where table would overflow the page. Added break-word wrapping to make the URLs go into new line and not overflow the table as a result of the adjustment.