### PR TITLE
add paper "Exploiting Hybrid Semantics of Relation Paths for Multi-hop Question Answering over Knowledge Graphs"

### DIFF
--- a/freebase/WebQuestionsSP.md
+++ b/freebase/WebQuestionsSP.md
@@ -11,6 +11,7 @@
 |              GPT-3.5v3              | 2023 |     -      |     -      |  79.60   |    EN    |                  [Tan et al.](https://arxiv.org/pdf/2303.07992.pdf)                   |
 |       DECAF (DPR + FiD-large)       | 2022 | 77.1 ± 0.2 | 80.7 ± 0.2 |    -     |    EN    |                   [Yu et al.](https://arxiv.org/pdf/2210.00063.pdf)                   |
 |               UniK-QA               | 2022 |     -      |    79.1    |    -     |    EN    |                   [Yu et al.](https://arxiv.org/pdf/2210.00063.pdf)                   |
+|                TERP                 | 2022 |     -      |    76.8    |    -     |    EN    |              [Qiao et al.](https://aclanthology.org/2022.coling-1.156.pdf)            |
 |             SQALER+GNN              | 2022 |     -      |    76.1    |    -     |    EN    |     [Costas Mavromatis and George Karypis](https://arxiv.org/pdf/2210.13650.pdf)      |
 |                EmQL                 | 2020 |     -      |    75.5    |    -     |    EN    |                   [Yu et al.](https://arxiv.org/pdf/2210.00063.pdf)                   |
 |              GMT-KBQA               | 2022 |    76.6    |     -      |   73.1   |    EN    |              [Hu et al.](https://aclanthology.org/2022.coling-1.145.pdf)              |

--- a/other/MetaQA - 1 Hop.md
+++ b/other/MetaQA - 1 Hop.md
@@ -18,6 +18,7 @@
 |             GlobalGraph             | 2022 |  99.0  | 97.6 |      -      |    EN    |    [Zhang et al.](https://downloads.hindawi.com/journals/cin/2022/4734179.pdf)     |
 |               2HR-DR                | 2022 |  98.8  | 97.3 |      -      |    EN    |    [Zhang et al.](https://downloads.hindawi.com/journals/cin/2022/4734179.pdf)     |
 |              SGReader               | 2022 |  96.7  | 96.0 |      -      |    EN    |    [Zhang et al.](https://downloads.hindawi.com/journals/cin/2022/4734179.pdf)     |
+|                TERP                 | 2022 |  97.5  |  -   |      -      |    EN    |           [Qiao et al.](https://aclanthology.org/2022.coling-1.156.pdf)            |
 |              GRAFT-Net              | 2022 |  97.4  | 91.0 |      -      |    EN    |    [Zhang et al.](https://downloads.hindawi.com/journals/cin/2022/4734179.pdf)     |
 |            ARN_DistMult             | 2023 | 97.12  |  -   |      -      |    EN    |                 [Cui et al.](https://www.sciencedirect.com/science/article/abs/pii/S0020025522013317)                  |
 |              ARN_TuckER               | 2023 | 97.11  |  -   |      -      |    EN    |                 [Cui et al.](https://www.sciencedirect.com/science/article/abs/pii/S0020025522013317)                  |

--- a/other/MetaQA - 2 Hop.md
+++ b/other/MetaQA - 2 Hop.md
@@ -15,6 +15,7 @@
 |               QNRKGQA               | 2022 |  99.9  |  -   |      -      |    EN    |    [Ma et al.](https://link.springer.com/chapter/10.1007/978-3-031-10983-6_11)     |
 |              QNRKGQA+h              | 2022 |  99.9  |  -   |      -      |    EN    |    [Ma et al.](https://link.springer.com/chapter/10.1007/978-3-031-10983-6_11)     |
 |               SSKGQA                | 2022 |  99.7  |  -   |      -      |    EN    |     [Mingchen Li and Jonathan Shihao Ji](https://arxiv.org/pdf/2204.10194.pdf)     |
+|                TERP                 | 2022 |  99.4  |  -   |      -      |    EN    |           [Qiao et al.](https://aclanthology.org/2022.coling-1.156.pdf)            |
 |              EmbedKGQA              | 2020 |  98.8  |  -   |      -      |    EN    |          [Saxena et al.](https://aclanthology.org/2020.acl-main.412.pdf)           |
 |             TransferNet             | 2022 |  98.5  |  -   |      -      |    EN    |     [Mingchen Li and Jonathan Shihao Ji](https://arxiv.org/pdf/2204.10194.pdf)     |
 |                NRQA                 | 2022 |  97.5  |  -   |      -      |    EN    | [Guo et al.](https://link.springer.com/content/pdf/10.1007/s10489-022-03927-0.pdf) |

--- a/other/MetaQA - 3 Hop.md
+++ b/other/MetaQA - 3 Hop.md
@@ -12,6 +12,7 @@
 |                NSM+h                | 2021 |  98.9  |  -   |      -       |    EN    |             [He et al.](https://arxiv.org/pdf/2101.03737.pdf)              |
 |               QNRKGQA               | 2022 |  98.9  |  -   |      -       |    EN    |    [Ma et al.](https://link.springer.com/chapter/10.1007/978-3-031-10983-6_11)     |
 |              QNRKGQA+h              | 2022 |  98.9  |  -   |      -       |    EN    |    [Ma et al.](https://link.springer.com/chapter/10.1007/978-3-031-10983-6_11)     |
+|                TERP                 | 2022 |  98.9  |  -   |      -       |    EN    |           [Qiao et al.](https://aclanthology.org/2022.coling-1.156.pdf)            |
 | KGQA Based on Query Path Generation | 2022 |  98.5  |  -   |      -       |    EN    |    [Yang et al.](https://link.springer.com/chapter/10.1007/978-3-031-10983-6_12)|
 |                QAGCN                | 2022 |  97.6  |  -   |      -       |    EN    |       [Wang et al.](https://arxiv.org/pdf/2206.01818.pdf)             |
 |              ARN_ConvE              | 2023 | 97.06  |  -   |      -      |    EN    |                 [Cui et al.](https://www.sciencedirect.com/science/article/abs/pii/S0020025522013317)                  |


### PR DESCRIPTION
relevant issue: https://github.com/KGQA/leaderboard/issues/159

It should be noted that the new model TERP was already contained in ComplexWebQuestions.md and systems.md. I only added values to WebQSP and MetaQA (1, 2 and 3 Hop).